### PR TITLE
Add doxygen documentation for JSON library

### DIFF
--- a/source/include/core_json.h
+++ b/source/include/core_json.h
@@ -73,14 +73,8 @@ typedef enum
  *
  *     result = JSON_Validate( buf, bufLength );
  *
- *     if( result == JSONSuccess )
- *     {
- *         // JSON document is valid.
- *     }
- *     else
- *     {
- *         // JSON document is invalid.
- *     }
+ *     // JSON document is valid.
+ *     assert( result == JSONSuccess );
  * @endcode
  */
 /* @[declare_json_validate] */
@@ -139,7 +133,7 @@ JSONStatus_t JSON_Validate( const char * buf,
  *     char * value;
  *     size_t valueLength;
  *
- *     // If you know the JSON document is valid, this call is not necessary.
+ *     // Calling JSON_Validate() is not necessary if the document is guaranteed to be valid.
  *     result = JSON_Validate( buf, bufLength );
  *
  *     if( result == JSONSuccess )


### PR DESCRIPTION
If you would like to view the generated documentation from doxygen, please install `doxygen`, then run the following command in the root directory of this repo:
```bash
doxygen docs/doxygen/config.doxyfile
```

Simply open `docs/doxygen/output/index.html`.