### PR TITLE
Update code sizes

### DIFF
--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -16,7 +16,7 @@ The configurations for memory estimation are defined <a href="https://github.com
 
 <table>
     <tr>
-        <td colspan="4"><center><b>Code Size of coreJSON library files (sizes generated with [GCC for ARM Cortex-M toolchain 20191025](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads))</b></center></td>
+        <td colspan="4"><center><b>Code Size of coreJSON library files (sizes generated with [GCC for ARM Cortex-M toolchain 20191025](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads/9-2019-q4-major))</b></center></td>
     </tr>
     <tr>
         <td><b>File</b></td>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -20,18 +20,21 @@ The configurations for memory estimation are defined <a href="https://github.com
     </tr>
     <tr>
         <td><b>File</b></td>
-        <td><b>With -O1 Optimisation</b></td>
-        <td><b>With -Os Optimisation</b></td>
+        <td><b>No Optimisation (asserts enabled)</b></td>
+        <td><b>With -O1 Optimisation (asserts disabled)</b></td>
+        <td><b>With -Os Optimisation (asserts disabled)</b></td>
     </tr>
     <tr>
         <td>core_json.c</td>
-        <td>4.3K</td>
-        <td>3.5K</td>
+        <td>9.1K</td>
+        <td>3.1K</td>
+        <td>2.7K</td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td>4.3K</td>
-        <td>3.5K</td>
+        <td>9.1K</td>
+        <td>3.1K</td>
+        <td>2.7K</td>
     </tr>
 </table>
  */

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -20,18 +20,12 @@ The configurations for memory estimation are defined <a href="https://github.com
     </tr>
     <tr>
         <td><b>File</b></td>
-        <td><b>No Optimisation (asserts enabled)</b></td>
-        <td><b>With -O1 Optimisation (asserts disabled)</b></td>
-        <td><b>With -Os Optimisation (asserts disabled)</b></td>
+        <td><b>No Optimization (asserts enabled)</b></td>
+        <td><b>With -O1 Optimization (asserts disabled)</b></td>
+        <td><b>With -Os Optimization (asserts disabled)</b></td>
     </tr>
     <tr>
         <td>core_json.c</td>
-        <td>9.1K</td>
-        <td>3.1K</td>
-        <td>2.7K</td>
-    </tr>
-    <tr>
-        <td><b>Total estimates</b></td>
         <td>9.1K</td>
         <td>3.1K</td>
         <td>2.7K</td>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -1,11 +1,10 @@
 /**
 @mainpage Overview
-@anchor json
 @brief coreJSON Library
 
 <p>
-A parser that supports key lookups while also strictly enforcing the ECMA-404 JSON standard.
-The library is written in C and designed to be compliant with ISO C90 and MISRA C. It has proven safe memory use
+A parser that supports key lookups while also strictly enforcing the ECMA-404 JSON standard. 
+The library is written in C and designed to be compliant with ISO C90 and MISRA C. It has proven safe memory use 
 and no heap allocation, making it suitable for IoT microcontrollers, but also fully portable to other platforms.
 </p>
 
@@ -25,13 +24,13 @@ The configurations for memory estimation are defined <a href="https://github.com
     </tr>
     <tr>
         <td>core_json.c</td>
-        <td>4.3K</td>
-        <td>3.5K</td>
+        <td>4.4K</td>
+        <td>3.6K</td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td>4.3K</td>
-        <td>3.5K</td>
+        <td>4.4K</td>
+        <td>3.6K</td>
     </tr>
 </table>
  */
@@ -43,21 +42,21 @@ JSON Library Design
 <h3>Memory Usage</h3>
 <p>
 All functions in the JSON library operate only on the buffers provided and use only
-local variables on the stack. In order to support static-only usage, we made a
+local variables on the stack. In order to support static-only usage, we made a 
 trade-off to re-parse as necessary so that we would not need to keep state.
 </p>
 
 <h3>Parsing Strictness</h3>
 <p>
-Input validation is necessary for strong security posture. As such, the parser
-strictly enforces the ECMA-404 JSON standard. Additionally, JSON documents are
+Input validation is necessary for strong security posture. As such, the parser 
+strictly enforces the ECMA-404 JSON standard. Additionally, JSON documents are  
 checked for illegal UTF8 sequences, and strings have unicode hex escapes validated.
 </p>
 
 <h3>Compliance & Coverage</h3>
 <p>
 The JSON library is designed to be compliant with ISO C90 and MISRA C.
-All functions are written to have minimal complexity. Unit tests and CBMC proofs
+All functions are written to have minimal complexity. Unit tests and CBMC proofs 
 are written to cover every path of execution and achieve 100% branch coverage.
 </p>
 */

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -3,8 +3,8 @@
 @brief coreJSON Library
 
 <p>
-A parser that supports key lookups while also strictly enforcing the ECMA-404 JSON standard. 
-The library is written in C and designed to be compliant with ISO C90 and MISRA C. It has proven safe memory use 
+A parser that supports key lookups while also strictly enforcing the ECMA-404 JSON standard.
+The library is written in C and designed to be compliant with ISO C90 and MISRA C. It has proven safe memory use
 and no heap allocation, making it suitable for IoT microcontrollers, but also fully portable to other platforms.
 </p>
 
@@ -42,21 +42,21 @@ JSON Library Design
 <h3>Memory Usage</h3>
 <p>
 All functions in the JSON library operate only on the buffers provided and use only
-local variables on the stack. In order to support static-only usage, we made a 
+local variables on the stack. In order to support static-only usage, we made a
 trade-off to re-parse as necessary so that we would not need to keep state.
 </p>
 
 <h3>Parsing Strictness</h3>
 <p>
-Input validation is necessary for strong security posture. As such, the parser 
-strictly enforces the ECMA-404 JSON standard. Additionally, JSON documents are  
+Input validation is necessary for strong security posture. As such, the parser
+strictly enforces the ECMA-404 JSON standard. Additionally, JSON documents are
 checked for illegal UTF8 sequences, and strings have unicode hex escapes validated.
 </p>
 
 <h3>Compliance & Coverage</h3>
 <p>
 The JSON library is designed to be compliant with ISO C90 and MISRA C.
-All functions are written to have minimal complexity. Unit tests and CBMC proofs 
+All functions are written to have minimal complexity. Unit tests and CBMC proofs
 are written to cover every path of execution and achieve 100% branch coverage.
 </p>
 */

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -16,7 +16,7 @@ The configurations for memory estimation are defined <a href="https://github.com
 
 <table>
     <tr>
-        <td colspan="3"><b>Code Size of coreJSON (example generated with GCC for ARM Cortex-M)</b></td>
+        <td colspan="4"><center><b>Code Size of coreJSON library files (sizes generated with [GCC for ARM Cortex-M toolchain 20191025](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads))</b></center></td>
     </tr>
     <tr>
         <td><b>File</b></td>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -1,5 +1,6 @@
 /**
 @mainpage Overview
+@anchor json
 @brief coreJSON Library
 
 <p>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -25,13 +25,13 @@ The configurations for memory estimation are defined <a href="https://github.com
     </tr>
     <tr>
         <td>core_json.c</td>
-        <td>4.4K</td>
-        <td>3.6K</td>
+        <td>4.3K</td>
+        <td>3.5K</td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td>4.4K</td>
-        <td>3.6K</td>
+        <td>4.3K</td>
+        <td>3.5K</td>
     </tr>
 </table>
  */


### PR DESCRIPTION
I calculated code sizes after adding version numbers in PR #24  

**Note: I am always rounding up.**

O0:
size -t libcoverity_analysis.a
```
   text    data     bss     dec     hex filename
   9231       0       0    9231    240f core_json.c.obj (ex libcoverity_analysis.a)
   9231       0       0    9231    240f (TOTALS)
```
O1:
size -t libcoverity_analysis.a
```
   text    data     bss     dec     hex filename
   3133       0       0    3133     c3d core_json.c.obj (ex libcoverity_analysis.a)
   3133       0       0    3133     c3d (TOTALS)
```
Os:
size -t libcoverity_analysis.a
```
   text    data     bss     dec     hex filename
   2700       0       0    2700     a8c core_json.c.obj (ex libcoverity_analysis.a)
   2700       0       0    2700     a8c (TOTALS)
```