### PR TITLE
Delete irrelevant comment about memory estimation.

### DIFF
--- a/docs/doxygen/config.doxyfile
+++ b/docs/doxygen/config.doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "coreJSON"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "v1.0.0"
+PROJECT_NUMBER         = "V1.0.0"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docs/doxygen/config.doxyfile
+++ b/docs/doxygen/config.doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "coreJSON"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "V1.0.0"
+PROJECT_NUMBER         = "v1.0.0"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -12,8 +12,6 @@ and no heap allocation, making it suitable for IoT microcontrollers, but also fu
 @section json_memory_requirements Memory Requirements
 @brief Memory requirements of the JSON library.
 
-The configurations for memory estimation are defined <a href="https://github.com/FreeRTOS/FreeRTOS/tree/lts-development/tools/memory_estimator" target="_blank" rel="noopener noreferrer">here</a>.
-
 <table>
     <tr>
         <td colspan="4"><center><b>Code Size of coreJSON library files (sizes generated with [GCC for ARM Cortex-M toolchain 20191025](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads/9-2019-q4-major))</b></center></td>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,7 +38,7 @@ include( ${MODULE_ROOT_DIR}/jsonFilePaths.cmake )
 # Target for Coverity analysis that builds the library.
 add_library( coverity_analysis
              ${JSON_SOURCES} )
-# MQTT public include path.
+# JSON public include path.
 target_include_directories( coverity_analysis PUBLIC ${JSON_INCLUDE_PUBLIC_DIRS} )
 
 #  ====================================  Test Configuration ========================================


### PR DESCRIPTION
The memory estimation was found using the ARM tools directly and the comment above does not make sense for the documentation.