### PR TITLE
Update submodule configuration for hub repo cloning efficiency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v2
+      - name: Checkout CMock submodule
+        run: git submodule update --checkout --init --recursive test/unit-test/CMock
       - name: Build
         run: |
           sudo apt-get install -y lcov

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,12 @@
 [submodule "test/unit-test/CMock"]
 	path = test/unit-test/CMock
 	url = https://github.com/ThrowTheSwitch/CMock
+	update = none
 [submodule "test/cbmc/aws-templates-for-cbmc-proofs"]
 	path = test/cbmc/aws-templates-for-cbmc-proofs
 	url = https://github.com/awslabs/aws-templates-for-cbmc-proofs.git
+	update = none
 [submodule "test/cbmc/litani"]
 	path = test/cbmc/litani
 	url = https://github.com/awslabs/aws-build-accumulator
+	update = none

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ doxygen docs/doxygen/config.doxyfile
 
 ## Building unit tests
 
+### Checkout CMock Submodule
+By default, the submodules in this repository are configured with `update=none` in [.gitmodules](.gitmodules) to avoid increasing clone time and disk space usage of other repositories (like [amazon-freertos](https://github.com/aws/amazon-freertos) that submodule this repository.
+
+To build unit tests, the submodule dependency of CMock is required. Use the following command to clone the submodule:
+```
+git submodule update --checkout --init --recursive --test/unit-test/CMock
+```
+
 ### Platform Prerequisites
 
 - For running unit tests
@@ -83,7 +91,7 @@ doxygen docs/doxygen/config.doxyfile
 
 ### Steps to build Unit Tests
 
-1. Go to the root directory of this repository.
+1. Go to the root directory of this repository. (Make sure that the **CMock** submodule is cloned as described [above](#checkout-cmock-submodule).)
 
 1. Create build directory: `mkdir build && cd build`
 


### PR DESCRIPTION
Reduce the cloning time of hub repositories (`aws/aws-iot-device-sdk-embedded-C`, `aws/amazon-freertos`) that consume this repository by updating submodules to not be auto-cloned for `git submodule update --init --recursive` command in the hub repositories
﻿
