### PR TITLE
Modify CBMC proofs to make assumptions about malloc explicit.

### DIFF
--- a/test/cbmc/proofs/skipAnyLiteral/skipAnyLiteral_harness.c
+++ b/test/cbmc/proofs/skipAnyLiteral/skipAnyLiteral_harness.c
@@ -42,6 +42,7 @@ void harness()
 
     /* buf must not be NULL */
     buf = malloc( max );
+    __CPROVER_assume( buf != NULL );
 
     ret = skipAnyLiteral( buf, &start, max );
 

--- a/test/cbmc/proofs/skipCollection/skipCollection_harness.c
+++ b/test/cbmc/proofs/skipCollection/skipCollection_harness.c
@@ -42,6 +42,7 @@ void harness()
 
     /* buf must not be NULL */
     buf = malloc( max );
+    __CPROVER_assume( buf != NULL );
 
     ret = skipCollection( buf, &start, max );
 

--- a/test/cbmc/proofs/skipEscape/skipEscape_harness.c
+++ b/test/cbmc/proofs/skipEscape/skipEscape_harness.c
@@ -42,6 +42,7 @@ void harness()
 
     /* buf must not be NULL */
     buf = malloc( max );
+    __CPROVER_assume( buf != NULL );
 
     ret = skipEscape( buf, &start, max );
 

--- a/test/cbmc/proofs/skipNumber/skipNumber_harness.c
+++ b/test/cbmc/proofs/skipNumber/skipNumber_harness.c
@@ -42,6 +42,7 @@ void harness()
 
     /* buf must not be NULL */
     buf = malloc( max );
+    __CPROVER_assume( buf != NULL );
 
     ret = skipNumber( buf, &start, max );
 

--- a/test/cbmc/proofs/skipSpace/skipSpace_harness.c
+++ b/test/cbmc/proofs/skipSpace/skipSpace_harness.c
@@ -41,6 +41,7 @@ void harness()
 
     /* buf must not be NULL */
     buf = malloc( max );
+    __CPROVER_assume( buf != NULL );
 
     skipSpace( buf, &start, max );
 

--- a/test/cbmc/proofs/skipSpaceAndComma/skipSpaceAndComma_harness.c
+++ b/test/cbmc/proofs/skipSpaceAndComma/skipSpaceAndComma_harness.c
@@ -42,6 +42,7 @@ void harness()
 
     /* buf must not be NULL */
     buf = malloc( max );
+    __CPROVER_assume( buf != NULL );
 
     ret = skipSpaceAndComma( buf, &start, max );
 

--- a/test/cbmc/proofs/skipString/skipString_harness.c
+++ b/test/cbmc/proofs/skipString/skipString_harness.c
@@ -42,6 +42,7 @@ void harness()
 
     /* buf must not be NULL */
     buf = malloc( max );
+    __CPROVER_assume( buf != NULL );
 
     ret = skipString( buf, &start, max );
 

--- a/test/cbmc/proofs/skipUTF8/skipUTF8_harness.c
+++ b/test/cbmc/proofs/skipUTF8/skipUTF8_harness.c
@@ -42,6 +42,7 @@ void harness()
 
     /* buf must not be NULL */
     buf = malloc( max );
+    __CPROVER_assume( buf != NULL );
 
     ret = skipUTF8( buf, &start, max );
 


### PR DESCRIPTION
Some proofs assume that some pointers returned by malloc are not
NULL. This patch modifies those proofs to make these assumptions
explicit with `__CPROVER_assume(pointer != NULL)` for all such
pointers.