### PR TITLE
100% branch coverage for coreJSON unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Build
         run: |
-          sudo apt-get install -y lcov
+          sudo apt-get install -y lcov sed
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \
@@ -97,7 +97,7 @@ jobs:
       - name: Install Uncrustify
         run: sudo apt-get install uncrustify
       - name: Run Uncrustify
-        run: find . -iname "*.[hc]" -exec uncrustify --check -c tools/uncrustify.cfg {} +
+        run: find . -iname "*.[hc]" -exec uncrustify --check -c tools/uncrustify.cfg -l C {} +
       - name: Check For Trailing Whitespace
         run: |
           set +e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \
           -DBUILD_CLONE_SUBMODULES=ON \
-          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG'
+          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror'
           make -C build/ all
       - name: Test
         run: |
@@ -31,6 +31,7 @@ jobs:
           lcov --rc lcov_branch_coverage=1 --remove build/coverage.info '*test*' --output-file build/coverage.info
           lcov --rc lcov_branch_coverage=1 --remove build/coverage.info '*CMakeCCompilerId*' --output-file build/coverage.info
           lcov --rc lcov_branch_coverage=1 --remove build/coverage.info '*mocks*' --output-file build/coverage.info
+          lcov --rc lcov_branch_coverage=1 --remove build/coverage.info '*source*' --output-file build/coverage.info
           lcov --list build/coverage.info
       - name: lcov-cop
         uses: ChicagoFlutter/lcov-cop@v1.0.2

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -42,6 +42,7 @@ jsonstatus
 jsonsuccess
 keylength
 len
+longjmp
 min
 misra
 msb
@@ -73,6 +74,7 @@ skipspace
 skipspaceandcomma
 skipstring
 skiputf
+stderr
 sublicense
 uint
 unescaped

--- a/source/core_json.c
+++ b/source/core_json.c
@@ -51,11 +51,11 @@ typedef union
     ( ( ( x ) == ' ' ) || ( ( x ) == '\t' ) || \
       ( ( x ) == '\n' ) || ( ( x ) == '\r' ) )
 
-#define isOpenBracket_( x )     ( ( ( x ) == '{' ) || ( ( x ) == '[' ) )
-#define isCloseBracket_( x )    ( ( ( x ) == '}' ) || ( ( x ) == ']' ) )
-/* NB. The numeric values of the open and close bracket pairs differ by 2. */
-#define isMatchingBracket_( x, y ) \
-    ( isOpenBracket_( x ) && isCloseBracket_( y ) && ( ( x ) == ( ( y ) - 2 ) ) )
+#define isOpenBracket_( x )           ( ( ( x ) == '{' ) || ( ( x ) == '[' ) )
+#define isCloseBracket_( x )          ( ( ( x ) == '}' ) || ( ( x ) == ']' ) )
+#define isCurlyPair_( x, y )          ( ( ( x ) == '{' ) && ( ( y ) == '}' ) )
+#define isSquarePair_( x, y )         ( ( ( x ) == '[' ) && ( ( y ) == ']' ) )
+#define isMatchingBracket_( x, y )    ( isCurlyPair_( x, y ) || isSquarePair_( x, y ) )
 
 /**
  * @brief Advance buffer index beyond whitespace.

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -6,9 +6,26 @@ set(project_name "core_json")
 # =====================  Create your mock here  (edit)  ========================
 # ================= Create the library under test here (edit) ==================
 
+# Base name for temporary files
+set( TEMP_BASE ${CMAKE_BINARY_DIR}/${project_name} )
+
+# Strip static constraints so unit tests may call internal functions
+execute_process( COMMAND sed "s/^static //"
+                 WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                 INPUT_FILE ${JSON_SOURCES}
+                 OUTPUT_FILE ${TEMP_BASE}.c
+        )
+
+# Generate a header file for internal functions
+execute_process( COMMAND sed -n "1s/.*/typedef int bool_;/p; /^static.*(/,/^{\$/{s/^static //; s/)\$/&;/; /{/d; p;}"
+                 WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                 INPUT_FILE ${JSON_SOURCES}
+                 OUTPUT_FILE ${TEMP_BASE}_annex.h
+        )
+
 # list the files you would like to test here
 list(APPEND real_source_files
-            ${JSON_SOURCES}
+            ${TEMP_BASE}.c
         )
 # list the directories the module under test includes
 list(APPEND real_include_directories
@@ -20,6 +37,8 @@ list(APPEND real_include_directories
 # list the directories your test needs to include
 list(APPEND test_include_directories
             ${JSON_INCLUDE_PUBLIC_DIRS}
+            ${UNIT_TEST_DIR}
+            ${CMAKE_BINARY_DIR}
         )
 
 # =============================  (end edit)  ===================================

--- a/test/unit-test/catch_assert.h
+++ b/test/unit-test/catch_assert.h
@@ -43,10 +43,13 @@
 
 jmp_buf CATCH_JMPBUF;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
 static void catchHandler_( int signal )
 {
     longjmp( CATCH_JMPBUF, signal );
 }
+#pragma GCC diagnostic pop
 
 #define catch_assert( x )                    \
     do {                                     \

--- a/test/unit-test/catch_assert.h
+++ b/test/unit-test/catch_assert.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * How to catch an assert:
+ * - save a jump buffer where execution will resume after the assert
+ * - setup a handler for the abort signal, call longjmp within
+ * - optional - close stderr ( fd 2 ) to discard the assert message
+ *
+ * Unity also does a longjmp within its TEST_ASSERT* macros,
+ * so the macro below restores stderr and the prior abort handler
+ * before calling the Unity macro.
+ */
+
+#ifndef CATCH_ASSERT_H_
+#define CATCH_ASSERT_H_
+
+#include <setjmp.h>
+#include <signal.h>
+
+#ifndef CATCH_JMPBUF
+    #define CATCH_JMPBUF    waypoint_
+#endif
+
+jmp_buf CATCH_JMPBUF;
+
+static void catchHandler_( int signal )
+{
+    longjmp( CATCH_JMPBUF, 1 );
+}
+
+#define catch_assert( x )                       \
+    do {                                        \
+        int try = 0, catch = 0;                 \
+        int saveFd = dup( 2 );                  \
+        struct sigaction sa = { 0 }, saveSa;    \
+        sa.sa_handler = catchHandler_;          \
+        sigaction( SIGABRT, &sa, &saveSa );     \
+        close( 2 );                             \
+        if( setjmp( CATCH_JMPBUF ) == 0 )       \
+        {                                       \
+            try++;                              \
+            x;                                  \
+        }                                       \
+        else                                    \
+        {                                       \
+            catch++;                            \
+        }                                       \
+        sigaction( SIGABRT, &saveSa, NULL );    \
+        dup2( saveFd, 2 );                      \
+        close( saveFd );                        \
+        TEST_ASSERT_EQUAL( try, catch );        \
+    } while ( 0 )
+
+#endif /* ifndef CATCH_ASSERT_H_ */

--- a/test/unit-test/catch_assert.h
+++ b/test/unit-test/catch_assert.h
@@ -48,27 +48,27 @@ static void catchHandler_( int signal )
     longjmp( CATCH_JMPBUF, signal );
 }
 
-#define catch_assert( x )                       \
-    do {                                        \
-        int try = 0, catch = 0;                 \
-        int saveFd = dup( 2 );                  \
-        struct sigaction sa = { 0 }, saveSa;    \
-        sa.sa_handler = catchHandler_;          \
-        sigaction( SIGABRT, &sa, &saveSa );     \
-        close( 2 );                             \
-        if( setjmp( CATCH_JMPBUF ) == 0 )       \
-        {                                       \
-            try++;                              \
-            x;                                  \
-        }                                       \
-        else                                    \
-        {                                       \
-            catch++;                            \
-        }                                       \
-        sigaction( SIGABRT, &saveSa, NULL );    \
-        dup2( saveFd, 2 );                      \
-        close( saveFd );                        \
-        TEST_ASSERT_EQUAL( try, catch );        \
-    } while ( 0 )
+#define catch_assert( x )                    \
+    do {                                     \
+        int try = 0, catch = 0;              \
+        int saveFd = dup( 2 );               \
+        struct sigaction sa = { 0 }, saveSa; \
+        sa.sa_handler = catchHandler_;       \
+        sigaction( SIGABRT, &sa, &saveSa );  \
+        close( 2 );                          \
+        if( setjmp( CATCH_JMPBUF ) == 0 )    \
+        {                                    \
+            try++;                           \
+            x;                               \
+        }                                    \
+        else                                 \
+        {                                    \
+            catch++;                         \
+        }                                    \
+        sigaction( SIGABRT, &saveSa, NULL ); \
+        dup2( saveFd, 2 );                   \
+        close( saveFd );                     \
+        TEST_ASSERT_EQUAL( try, catch );     \
+    } while( 0 )
 
 #endif /* ifndef CATCH_ASSERT_H_ */

--- a/test/unit-test/catch_assert.h
+++ b/test/unit-test/catch_assert.h
@@ -35,6 +35,7 @@
 
 #include <setjmp.h>
 #include <signal.h>
+#include <unistd.h>
 
 #ifndef CATCH_JMPBUF
     #define CATCH_JMPBUF    waypoint_
@@ -44,7 +45,7 @@ jmp_buf CATCH_JMPBUF;
 
 static void catchHandler_( int signal )
 {
-    longjmp( CATCH_JMPBUF, 1 );
+    longjmp( CATCH_JMPBUF, signal );
 }
 
 #define catch_assert( x )                       \

--- a/test/unit-test/core_json_utest.c
+++ b/test/unit-test/core_json_utest.c
@@ -1471,7 +1471,7 @@ void test_JSON_Max_Depth( void )
  */
 void test_JSON_asserts( void )
 {
-    char buf[ ] = "x", queryKey[ ] = "y";
+    char buf[] = "x", queryKey[] = "y";
     size_t start = 1, max = 1, length = 1;
     uint16_t u = 0;
     size_t key, keyLength, value, valueLength;

--- a/test/unit-test/core_json_utest.c
+++ b/test/unit-test/core_json_utest.c
@@ -28,8 +28,10 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 #include "unity.h"
+#include "catch_assert.h"
 
 /* Include paths for public enums, structures, and macros. */
 #include "core_json.h"
@@ -131,6 +133,9 @@
 
 #define MISMATCHED_BRACKETS                                "{\"foo\":{\"bar\":\"xyz\"]}"
 #define MISMATCHED_BRACKETS_LENGTH                         ( sizeof( MISMATCHED_BRACKETS ) - 1 )
+
+#define MISMATCHED_BRACKETS2                               "{\"foo\":[\"bar\",\"xyz\"}}"
+#define MISMATCHED_BRACKETS2_LENGTH                        ( sizeof( MISMATCHED_BRACKETS ) - 1 )
 
 #define INCORRECT_OBJECT_SEPARATOR                         "{\"foo\": \"bar\"; \"bar\": \"foo\"}"
 #define INCORRECT_OBJECT_SEPARATOR_LENGTH                  ( sizeof( INCORRECT_OBJECT_SEPARATOR ) - 1 )
@@ -569,6 +574,10 @@ void test_JSON_Validate_Illegal_Documents( void )
 
     jsonStatus = JSON_Validate( MISMATCHED_BRACKETS,
                                 MISMATCHED_BRACKETS_LENGTH );
+    TEST_ASSERT_EQUAL( JSONIllegalDocument, jsonStatus );
+
+    jsonStatus = JSON_Validate( MISMATCHED_BRACKETS2,
+                                MISMATCHED_BRACKETS2_LENGTH );
     TEST_ASSERT_EQUAL( JSONIllegalDocument, jsonStatus );
 
     jsonStatus = JSON_Validate( NUL_ESCAPE, NUL_ESCAPE_LENGTH );
@@ -1455,4 +1464,128 @@ void test_JSON_Max_Depth( void )
 
     free( maxNestedArray );
     free( maxNestedObject );
+}
+
+/**
+ * @brief Trip all asserts in internal functions.
+ */
+void test_JSON_asserts( void )
+{
+    char buf[ ] = "x", queryKey[ ] = "y";
+    size_t start = 1, max = 1, length = 1;
+    uint16_t u = 0;
+    size_t key, keyLength, value, valueLength;
+    char * outValue;
+
+    catch_assert( skipSpace( NULL, &start, max ) );
+    catch_assert( skipSpace( buf, NULL, max ) );
+    /* assert: max != 0 */
+    catch_assert( skipSpace( buf, &start, 0 ) );
+
+    /* first argument is length; assert: 2 <= length <= 4 */
+    catch_assert( shortestUTF8( 1, u ) );
+    catch_assert( shortestUTF8( 5, u ) );
+
+    catch_assert( skipUTF8MultiByte( NULL, &start, max ) );
+    catch_assert( skipUTF8MultiByte( buf, NULL, max ) );
+    catch_assert( skipUTF8MultiByte( buf, &start, 0 ) );
+    /* assert: start < max */
+    catch_assert( skipUTF8MultiByte( buf, &start, max ) );
+    /* assert: buf[0] < '\0' */
+    catch_assert( skipUTF8MultiByte( buf, &start, ( start + 1 ) ) );
+
+    catch_assert( skipUTF8( NULL, &start, max ) );
+    catch_assert( skipUTF8( buf, NULL, max ) );
+    catch_assert( skipUTF8( buf, &start, 0 ) );
+
+    catch_assert( skipOneHexEscape( NULL, &start, max, &u ) );
+    catch_assert( skipOneHexEscape( buf, NULL, max, &u ) );
+    catch_assert( skipOneHexEscape( buf, &start, 0, &u ) );
+    catch_assert( skipOneHexEscape( buf, &start, max, NULL ) );
+
+    catch_assert( skipHexEscape( NULL, &start, max ) );
+    catch_assert( skipHexEscape( buf, NULL, max ) );
+    catch_assert( skipHexEscape( buf, &start, 0 ) );
+
+    catch_assert( skipEscape( NULL, &start, max ) );
+    catch_assert( skipEscape( buf, NULL, max ) );
+    catch_assert( skipEscape( buf, &start, 0 ) );
+
+    catch_assert( skipString( NULL, &start, max ) );
+    catch_assert( skipString( buf, NULL, max ) );
+    catch_assert( skipString( buf, &start, 0 ) );
+
+    catch_assert( strnEq( NULL, buf, max ) );
+    catch_assert( strnEq( buf, NULL, max ) );
+
+    catch_assert( skipLiteral( NULL, &start, max, "lit", length ) );
+    catch_assert( skipLiteral( buf, NULL, max, "lit", length ) );
+    catch_assert( skipLiteral( buf, &start, 0, "lit", length ) );
+    catch_assert( skipLiteral( buf, &start, max, NULL, length ) );
+
+    catch_assert( skipDigits( NULL, &start, max ) );
+    catch_assert( skipDigits( buf, NULL, max ) );
+    catch_assert( skipDigits( buf, &start, 0 ) );
+
+    catch_assert( skipDecimals( NULL, &start, max ) );
+    catch_assert( skipDecimals( buf, NULL, max ) );
+    catch_assert( skipDecimals( buf, &start, 0 ) );
+
+    catch_assert( skipExponent( NULL, &start, max ) );
+    catch_assert( skipExponent( buf, NULL, max ) );
+    catch_assert( skipExponent( buf, &start, 0 ) );
+
+    catch_assert( skipNumber( NULL, &start, max ) );
+    catch_assert( skipNumber( buf, NULL, max ) );
+    catch_assert( skipNumber( buf, &start, 0 ) );
+
+    catch_assert( skipSpaceAndComma( NULL, &start, max ) );
+    catch_assert( skipSpaceAndComma( buf, NULL, max ) );
+    catch_assert( skipSpaceAndComma( buf, &start, 0 ) );
+
+    catch_assert( skipArrayScalars( NULL, &start, max ) );
+    catch_assert( skipArrayScalars( buf, NULL, max ) );
+    catch_assert( skipArrayScalars( buf, &start, 0 ) );
+
+    catch_assert( skipObjectScalars( NULL, &start, max ) );
+    catch_assert( skipObjectScalars( buf, NULL, max ) );
+    catch_assert( skipObjectScalars( buf, &start, 0 ) );
+
+    /* assert: mode is '[' or '{' */
+    catch_assert( skipScalars( buf, &start, max, '(' ) );
+
+    catch_assert( skipCollection( NULL, &start, max ) );
+    catch_assert( skipCollection( buf, NULL, max ) );
+    catch_assert( skipCollection( buf, &start, 0 ) );
+
+    catch_assert( nextKeyValuePair( NULL, &start, max, &key, &keyLength, &value, &valueLength ) );
+    catch_assert( nextKeyValuePair( buf, NULL, max, &key, &keyLength, &value, &valueLength ) );
+    catch_assert( nextKeyValuePair( buf, &start, 0, &key, &keyLength, &value, &valueLength ) );
+    catch_assert( nextKeyValuePair( buf, &start, max, NULL, &keyLength, &value, &valueLength ) );
+    catch_assert( nextKeyValuePair( buf, &start, max, &key, NULL, &value, &valueLength ) );
+    catch_assert( nextKeyValuePair( buf, &start, max, &key, &keyLength, NULL, &valueLength ) );
+    catch_assert( nextKeyValuePair( buf, &start, max, &key, &keyLength, &value, NULL ) );
+
+    catch_assert( search( NULL, max, queryKey, keyLength, &outValue, &valueLength ) );
+    catch_assert( search( buf, max, NULL, keyLength, &outValue, &valueLength ) );
+    catch_assert( search( buf, max, queryKey, keyLength, NULL, &valueLength ) );
+    catch_assert( search( buf, max, queryKey, keyLength, &outValue, NULL ) );
+}
+
+/**
+ * @brief These checks are not otherwise reached.
+ */
+void test_JSON_unreached( void )
+{
+    char buf[ 2 ];
+    size_t start, max;
+
+    /* return false when start >= max */
+    start = max = 1;
+    TEST_ASSERT_EQUAL( false, skipUTF8( "abc", &start, max ) );
+
+    /* return false when buf[ 0 ] != '\\' */
+    buf[ 0 ] = 'x';
+    start = 0;
+    TEST_ASSERT_EQUAL( false, skipEscape( buf, &start, sizeof( buf ) ) );
 }

--- a/test/unit-test/core_json_utest.c
+++ b/test/unit-test/core_json_utest.c
@@ -35,6 +35,7 @@
 
 /* Include paths for public enums, structures, and macros. */
 #include "core_json.h"
+#include "core_json_annex.h"
 
 
 /* Sample test from the docs. */


### PR DESCRIPTION
This PR adds test cases for all asserts, and 3 cases to reach remaining branch points.  In order to check the asserts, the normally static functions are exposed via automatically generated files.  One macro from the original source is changed to an equivalent expression.