### PR TITLE
Fix building failed at uninitialized varaiable issue for espressif in…

### DIFF
--- a/source/core_json.c
+++ b/source/core_json.c
@@ -1164,7 +1164,7 @@ static bool_ nextKeyValuePair( const char * buf,
                                size_t * valueLength )
 {
     bool_ ret = true;
-    size_t i, keyStart, valueStart;
+    size_t i, keyStart, valueStart = 0U;
 
     assert( ( buf != NULL ) && ( start != NULL ) && ( max > 0U ) );
     assert( ( key != NULL ) && ( keyLength != NULL ) );


### PR DESCRIPTION
The shadow demo in amazon freertos will use this module and failed due to "error: 'valueStart' may be used uninitialized in this function [-Werror=maybe-uninitialized]".
This PR will assign the variable a initial value which is '0' to fix the issue.