### PR TITLE
Update doxygen memory estimates and GCC toolchain link

### DIFF
--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -14,7 +14,7 @@ and no heap allocation, making it suitable for IoT microcontrollers, but also fu
 
 <table>
     <tr>
-        <td colspan="4"><center><b>Code Size of coreJSON library files (sizes generated with [GCC for ARM Cortex-M toolchain 20191025](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads/9-2019-q4-major))</b></center></td>
+        <td colspan="4"><center><b>Code size of coreJSON library files (sizes generated with [GCC for ARM Cortex-M toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads/9-2020-q2-update))</b></center></td>
     </tr>
     <tr>
         <td><b>File</b></td>
@@ -24,9 +24,9 @@ and no heap allocation, making it suitable for IoT microcontrollers, but also fu
     </tr>
     <tr>
         <td>core_json.c</td>
-        <td>9.1K</td>
-        <td>3.1K</td>
-        <td>2.7K</td>
+        <td>9.5K</td>
+        <td>4.7K</td>
+        <td>3.8K</td>
     </tr>
 </table>
  */


### PR DESCRIPTION
Updating library memory estimates and GCC toolchain download link, to point to the latest release. The README update to link to the memory estimates doxygen page will be in a separate PR.