### PR TITLE
Add MISRA rule 8.7 to MISRA.md.

### DIFF
--- a/MISRA.md
+++ b/MISRA.md
@@ -6,7 +6,6 @@ guidelines, with some noted exceptions. Compliance is checked with Coverity stat
 Deviations from the MISRA standard are listed below:
 
 ### Ignored by [Coverity Configuration](tools/coverity/misra.config)
-
 | Deviation | Category | Justification |
 | :-: | :-: | :-: |
 | Directive 4.9 | Advisory | Allow inclusion of function like macros. |
@@ -16,7 +15,9 @@ Deviations from the MISRA standard are listed below:
 | Rule 20.12 | Required | Allow use of `assert()`, which uses a parameter in both expanded and raw forms. |
 
 ### Flagged by Coverity
-*None.*
+| Deviation | Category | Justification |
+| :-: | :-: | :-: |
+| Rule 8.7 | Advisory | API functions are not used by the library; however, they must be externally visible in order to be used by an application. |
 
 ### Suppressed with Coverity Comments
 *None.*


### PR DESCRIPTION
When building the coverity_analysis build target, MISRA Rule 8.7 will show up because the library is built as statically linkable, with no application using the API.

CI will check this file for rules to not flag in the results.