### PR TITLE
Swap bool_ enum for stdbool.h

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,3 +146,18 @@ jobs:
         run: |
           git-secrets --register-aws
           git-secrets --scan
+  custom-standard-c-headers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone This Repo
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          mkdir -p override-include
+          cp source/include/stdbool.readme override-include/stdbool.h
+          cp source/include/stdint.readme override-include/stdint.h
+          cmake -S test -B build/ \
+          -G "Unix Makefiles" \
+          -DBUILD_CLONE_SUBMODULES=ON \
+          -DCMAKE_C_FLAGS='-Wall -Wextra -I../override-include'
+          make -C build/ coverity_analysis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,6 @@ jobs:
         run: |
           mkdir -p override-include
           cp source/include/stdbool.readme override-include/stdbool.h
-          cp source/include/stdint.readme override-include/stdint.h
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
           -DBUILD_CLONE_SUBMODULES=ON \

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ A search may descend through nested objects when the `queryKey` contains matchin
 
 A compiler that supports **C90 or later** such as *gcc* is required to build the library.
 
+The library uses a header file introduced in ISO C99, `stdbool.h`. For compilers that do not provide this header file, the [source/include](source/include) directory contains [stdbool.readme](source/include/stdbool.readme), which can be renamed to `stdbool.h`.
+
 For instance, if the example above is copied to a file named `example.c`, *gcc* can be used like so:
 ```bash
 gcc -I source/include example.c source/core_json.c -o example

--- a/source/core_json.c
+++ b/source/core_json.c
@@ -31,11 +31,6 @@
 #include "core_json.h"
 
 /** @cond DO_NOT_DOCUMENT */
-typedef enum
-{
-    true = 1,
-    false = 0
-} bool_;
 
 /* A compromise to satisfy both MISRA and CBMC */
 typedef union
@@ -124,10 +119,10 @@ static size_t countHighBits( uint8_t c )
  *
  * @note Disallow ASCII, as this is called only for multibyte sequences.
  */
-static bool_ shortestUTF8( size_t length,
-                           uint32_t value )
+static bool shortestUTF8( size_t length,
+                          uint32_t value )
 {
-    bool_ ret = false;
+    bool ret = false;
     uint32_t min, max;
 
     assert( ( length >= 2U ) && ( length <= 4U ) );
@@ -182,11 +177,11 @@ static bool_ shortestUTF8( size_t length,
  * would introduce a non-shortest sequence, and F5 or above would
  * introduce a value greater than the last code point, 0x10FFFF.
  */
-static bool_ skipUTF8MultiByte( const char * buf,
-                                size_t * start,
-                                size_t max )
+static bool skipUTF8MultiByte( const char * buf,
+                               size_t * start,
+                               size_t max )
 {
-    bool_ ret = false;
+    bool ret = false;
     size_t i, bitCount, j;
     uint32_t value = 0;
     char_ c;
@@ -246,11 +241,11 @@ static bool_ skipUTF8MultiByte( const char * buf,
  * @return true if a valid code point was present;
  * false otherwise.
  */
-static bool_ skipUTF8( const char * buf,
-                       size_t * start,
-                       size_t max )
+static bool skipUTF8( const char * buf,
+                      size_t * start,
+                      size_t max )
 {
-    bool_ ret = false;
+    bool ret = false;
 
     assert( ( buf != NULL ) && ( start != NULL ) && ( max > 0U ) );
 
@@ -321,12 +316,12 @@ static uint8_t hexToInt( char c )
  *
  * @note For the sake of security, \u0000 is disallowed.
  */
-static bool_ skipOneHexEscape( const char * buf,
-                               size_t * start,
-                               size_t max,
-                               uint16_t * outValue )
+static bool skipOneHexEscape( const char * buf,
+                              size_t * start,
+                              size_t max,
+                              uint16_t * outValue )
 {
-    bool_ ret = false;
+    bool ret = false;
     size_t i, end;
     uint16_t value = 0;
 
@@ -382,11 +377,11 @@ static bool_ skipOneHexEscape( const char * buf,
 #define isHighSurrogate( x )    ( ( ( x ) >= 0xD800U ) && ( ( x ) <= 0xDBFFU ) )
 #define isLowSurrogate( x )     ( ( ( x ) >= 0xDC00U ) && ( ( x ) <= 0xDFFFU ) )
 
-static bool_ skipHexEscape( const char * buf,
-                            size_t * start,
-                            size_t max )
+static bool skipHexEscape( const char * buf,
+                           size_t * start,
+                           size_t max )
 {
-    bool_ ret = false;
+    bool ret = false;
     size_t i;
     uint16_t value;
 
@@ -434,11 +429,11 @@ static bool_ skipHexEscape( const char * buf,
  *
  * @note For the sake of security, \NUL is disallowed.
  */
-static bool_ skipEscape( const char * buf,
-                         size_t * start,
-                         size_t max )
+static bool skipEscape( const char * buf,
+                        size_t * start,
+                        size_t max )
 {
-    bool_ ret = false;
+    bool ret = false;
     size_t i;
 
     assert( ( buf != NULL ) && ( start != NULL ) && ( max > 0U ) );
@@ -501,11 +496,11 @@ static bool_ skipEscape( const char * buf,
  * @return true if a valid string was present;
  * false otherwise.
  */
-static bool_ skipString( const char * buf,
-                         size_t * start,
-                         size_t max )
+static bool skipString( const char * buf,
+                        size_t * start,
+                        size_t max )
 {
-    bool_ ret = false;
+    bool ret = false;
     size_t i;
 
     assert( ( buf != NULL ) && ( start != NULL ) && ( max > 0U ) );
@@ -566,9 +561,9 @@ static bool_ skipString( const char * buf,
  * @return true if the sequences are the same;
  * false otherwise
  */
-static bool_ strnEq( const char * a,
-                     const char * b,
-                     size_t n )
+static bool strnEq( const char * a,
+                    const char * b,
+                    size_t n )
 {
     size_t i;
 
@@ -597,13 +592,13 @@ static bool_ strnEq( const char * a,
  * @return true if the literal was present;
  * false otherwise.
  */
-static bool_ skipLiteral( const char * buf,
-                          size_t * start,
-                          size_t max,
-                          const char * literal,
-                          size_t length )
+static bool skipLiteral( const char * buf,
+                         size_t * start,
+                         size_t max,
+                         const char * literal,
+                         size_t length )
 {
-    bool_ ret = false;
+    bool ret = false;
 
     assert( ( buf != NULL ) && ( start != NULL ) && ( max > 0U ) );
     assert( literal != NULL );
@@ -631,14 +626,14 @@ static bool_ skipLiteral( const char * buf,
  * @return true if a valid literal was present;
  * false otherwise.
  */
-static bool_ skipAnyLiteral( const char * buf,
-                             size_t * start,
-                             size_t max )
+static bool skipAnyLiteral( const char * buf,
+                            size_t * start,
+                            size_t max )
 {
-    bool_ ret = false;
+    bool ret = false;
 
 #define skipLit_( x ) \
-    ( skipLiteral( buf, start, max, ( x ), ( sizeof( x ) - 1U ) ) == true )
+    ( skipLiteral( buf, start, max, ( x ), ( sizeof( x ) - 1UL ) ) == true )
 
     if( skipLit_( "true" ) || skipLit_( "false" ) || skipLit_( "null" ) )
     {
@@ -664,12 +659,12 @@ static bool_ skipAnyLiteral( const char * buf,
  * false otherwise.
  */
 #define MAX_FACTOR    ( MAX_INDEX_VALUE / 10 )
-static bool_ skipDigits( const char * buf,
-                         size_t * start,
-                         size_t max,
-                         int32_t * outValue )
+static bool skipDigits( const char * buf,
+                        size_t * start,
+                        size_t max,
+                        int32_t * outValue )
 {
-    bool_ ret = false;
+    bool ret = false;
     size_t i, saveStart;
     int32_t value = 0;
 
@@ -784,11 +779,11 @@ static void skipExponent( const char * buf,
  * @return true if a valid number was present;
  * false otherwise.
  */
-static bool_ skipNumber( const char * buf,
-                         size_t * start,
-                         size_t max )
+static bool skipNumber( const char * buf,
+                        size_t * start,
+                        size_t max )
 {
-    bool_ ret = false;
+    bool ret = false;
     size_t i;
 
     assert( ( buf != NULL ) && ( start != NULL ) && ( max > 0U ) );
@@ -840,11 +835,11 @@ static bool_ skipNumber( const char * buf,
  * @return true if a scalar value was present;
  * false otherwise.
  */
-static bool_ skipAnyScalar( const char * buf,
-                            size_t * start,
-                            size_t max )
+static bool skipAnyScalar( const char * buf,
+                           size_t * start,
+                           size_t max )
 {
-    bool_ ret = false;
+    bool ret = false;
 
     if( ( skipString( buf, start, max ) == true ) ||
         ( skipAnyLiteral( buf, start, max ) == true ) ||
@@ -870,11 +865,11 @@ static bool_ skipAnyScalar( const char * buf,
  * @return true if a non-terminal comma was present;
  * false otherwise.
  */
-static bool_ skipSpaceAndComma( const char * buf,
-                                size_t * start,
-                                size_t max )
+static bool skipSpaceAndComma( const char * buf,
+                               size_t * start,
+                               size_t max )
 {
-    bool_ ret = false;
+    bool ret = false;
     size_t i;
 
     assert( ( buf != NULL ) && ( start != NULL ) && ( max > 0U ) );
@@ -952,7 +947,7 @@ static void skipObjectScalars( const char * buf,
                                size_t max )
 {
     size_t i;
-    bool_ comma;
+    bool comma;
 
     assert( ( buf != NULL ) && ( start != NULL ) && ( max > 0U ) );
 
@@ -1183,13 +1178,13 @@ JSONStatus_t JSON_Validate( const char * buf,
  * @return true if a value was present;
  * false otherwise.
  */
-static bool_ nextValue( const char * buf,
-                        size_t * start,
-                        size_t max,
-                        size_t * value,
-                        size_t * valueLength )
+static bool nextValue( const char * buf,
+                       size_t * start,
+                       size_t max,
+                       size_t * value,
+                       size_t * valueLength )
 {
-    bool_ ret = true;
+    bool ret = true;
     size_t i, valueStart;
 
     assert( ( buf != NULL ) && ( start != NULL ) && ( max > 0U ) );
@@ -1234,15 +1229,15 @@ static bool_ nextValue( const char * buf,
  * @return true if a key-value pair was present;
  * false otherwise.
  */
-static bool_ nextKeyValuePair( const char * buf,
-                               size_t * start,
-                               size_t max,
-                               size_t * key,
-                               size_t * keyLength,
-                               size_t * value,
-                               size_t * valueLength )
+static bool nextKeyValuePair( const char * buf,
+                              size_t * start,
+                              size_t max,
+                              size_t * key,
+                              size_t * keyLength,
+                              size_t * value,
+                              size_t * valueLength )
 {
-    bool_ ret = true;
+    bool ret = true;
     size_t i, keyStart;
 
     assert( ( buf != NULL ) && ( start != NULL ) && ( max > 0U ) );
@@ -1307,14 +1302,14 @@ static bool_ nextKeyValuePair( const char * buf,
  *
  * @note Parsing stops upon finding a match.
  */
-static bool_ objectSearch( const char * buf,
-                           size_t max,
-                           const char * query,
-                           size_t queryLength,
-                           size_t * outValue,
-                           size_t * outValueLength )
+static bool objectSearch( const char * buf,
+                          size_t max,
+                          const char * query,
+                          size_t queryLength,
+                          size_t * outValue,
+                          size_t * outValueLength )
 {
-    bool_ ret = false;
+    bool ret = false;
 
     size_t i = 0, key, keyLength, value = 0, valueLength = 0;
 
@@ -1375,13 +1370,13 @@ static bool_ objectSearch( const char * buf,
  *
  * @note Parsing stops upon finding a match.
  */
-static bool_ arraySearch( const char * buf,
-                          size_t max,
-                          uint32_t queryIndex,
-                          size_t * outValue,
-                          size_t * outValueLength )
+static bool arraySearch( const char * buf,
+                         size_t max,
+                         uint32_t queryIndex,
+                         size_t * outValue,
+                         size_t * outValueLength )
 {
-    bool_ ret = false;
+    bool ret = false;
     size_t i = 0, value = 0, valueLength = 0;
     uint32_t currentIndex = 0;
 
@@ -1442,12 +1437,12 @@ static bool_ arraySearch( const char * buf,
  */
 #define JSON_QUERY_KEY_SEPARATOR    '.'
 #define isSeparator_( x )    ( ( x ) == JSON_QUERY_KEY_SEPARATOR )
-static bool_ skipQueryPart( const char * buf,
-                            size_t * start,
-                            size_t max,
-                            size_t * outLength )
+static bool skipQueryPart( const char * buf,
+                           size_t * start,
+                           size_t max,
+                           size_t * outLength )
 {
-    bool_ ret = false;
+    bool ret = false;
     size_t i;
 
     assert( ( buf != NULL ) && ( start != NULL ) && ( outLength != NULL ) );
@@ -1505,7 +1500,7 @@ static JSONStatus_t multiSearch( const char * buf,
 
     while( i < queryLength )
     {
-        bool_ found = false;
+        bool found = false;
 
         if( isSquareOpen_( query[ i ] ) )
         {

--- a/source/include/core_json.h
+++ b/source/include/core_json.h
@@ -28,6 +28,7 @@
 #ifndef CORE_JSON_H_
 #define CORE_JSON_H_
 
+#include <stdbool.h>
 #include <stddef.h>
 
 /**

--- a/source/include/stdbool.readme
+++ b/source/include/stdbool.readme
@@ -1,0 +1,30 @@
+#ifndef _STDBOOL_H
+#define _STDBOOL_H
+
+/*******************************************************************************
+ * This file contains the definitions specified in stdbool.h. It is provided to
+ * allow the library to be built using compilers that do not provide their own
+ * stdbool.h defintion.
+ *
+ * To use this file:
+ *
+ *    1) Copy this file into a directory that is in your compiler's include path.
+ *       The directory must be part of the include path for system header files,
+ *       for example passed using gcc's "-I" or "-isystem" options.
+ *
+ *    2) Rename the copied file stdbool.h.
+ *
+ */
+
+#ifndef __cplusplus
+
+/* _Bool was introduced in C99. */
+    #define bool     int
+    #define false    0
+    #define true     1
+
+#endif
+
+#define __bool_true_false_are_defined    1
+
+#endif /* _STDBOOL_H */

--- a/test/cbmc/include/core_json_annex.h
+++ b/test/cbmc/include/core_json_annex.h
@@ -27,12 +27,7 @@
 
 #include "core_json.h"
 
-typedef enum
-{
-    true = 1, false = 0
-} bool_;
-
-#define boolEnum( x )         ( ( x == true ) || ( x == false ) )
+#define isBool( x )           ( ( x == true ) || ( x == false ) )
 
 /* parameter check fail values for JSON API functions */
 #define parameterEnum( x )    ( ( x == JSONNullParameter ) || ( x == JSONBadParameter ) )
@@ -69,38 +64,38 @@ void skipSpace( const char * buf,
                 size_t * start,
                 size_t max );
 
-bool_ skipUTF8( const char * buf,
-                size_t * start,
-                size_t max );
+bool skipUTF8( const char * buf,
+               size_t * start,
+               size_t max );
 
-bool_ skipEscape( const char * buf,
-                  size_t * start,
-                  size_t max );
+bool skipEscape( const char * buf,
+                 size_t * start,
+                 size_t max );
 
-bool_ skipString( const char * buf,
-                  size_t * start,
-                  size_t max );
+bool skipString( const char * buf,
+                 size_t * start,
+                 size_t max );
 
-bool_ skipAnyLiteral( const char * buf,
-                      size_t * start,
-                      size_t max );
-
-bool_ skipDigits( const char * buf,
-                  size_t * start,
-                  size_t max,
-                  int32_t * outValue );
-
-bool_ skipNumber( const char * buf,
-                  size_t * start,
-                  size_t max );
-
-bool_ skipSpaceAndComma( const char * buf,
-                         size_t * start,
-                         size_t max );
-
-bool_ skipAnyScalar( const char * buf,
+bool skipAnyLiteral( const char * buf,
                      size_t * start,
                      size_t max );
+
+bool skipDigits( const char * buf,
+                 size_t * start,
+                 size_t max,
+                 int32_t * outValue );
+
+bool skipNumber( const char * buf,
+                 size_t * start,
+                 size_t max );
+
+bool skipSpaceAndComma( const char * buf,
+                        size_t * start,
+                        size_t max );
+
+bool skipAnyScalar( const char * buf,
+                    size_t * start,
+                    size_t max );
 
 JSONStatus_t skipCollection( const char * buf,
                              size_t * start,

--- a/test/cbmc/include/skipGeneric.h
+++ b/test/cbmc/include/skipGeneric.h
@@ -41,9 +41,9 @@
  * if true, the index in start will increment by at least min
  * but will not exceed max.
  */
-bool_ skipGeneric( const char * buf,
-                   size_t * start,
-                   size_t max,
-                   size_t min );
+bool skipGeneric( const char * buf,
+                  size_t * start,
+                  size_t max,
+                  size_t min );
 
 #endif /* ifndef SKIPGENERIC_H_ */

--- a/test/cbmc/proofs/skipAnyLiteral/skipAnyLiteral_harness.c
+++ b/test/cbmc/proofs/skipAnyLiteral/skipAnyLiteral_harness.c
@@ -32,7 +32,7 @@ void harness()
 {
     char * buf;
     size_t start, max;
-    bool_ ret;
+    bool ret;
 
     /* max is the buffer length which must be nonzero for non-API functions. */
     __CPROVER_assume( max > 0 );
@@ -46,7 +46,7 @@ void harness()
 
     ret = skipAnyLiteral( buf, &start, max );
 
-    __CPROVER_assert( boolEnum( ret ), "A bool_ value is returned." );
+    __CPROVER_assert( isBool( ret ), "A bool value is returned." );
 
     if( ret == true )
     {

--- a/test/cbmc/proofs/skipEscape/skipEscape_harness.c
+++ b/test/cbmc/proofs/skipEscape/skipEscape_harness.c
@@ -32,7 +32,7 @@ void harness()
 {
     char * buf;
     size_t start, max;
-    bool_ ret;
+    bool ret;
 
     /* max is the buffer length which must be nonzero for non-API functions. */
     __CPROVER_assume( max > 0 );
@@ -46,7 +46,7 @@ void harness()
 
     ret = skipEscape( buf, &start, max );
 
-    __CPROVER_assert( boolEnum( ret ), "A bool_ value is returned." );
+    __CPROVER_assert( isBool( ret ), "A bool value is returned." );
 
     if( ret == true )
     {

--- a/test/cbmc/proofs/skipNumber/skipNumber_harness.c
+++ b/test/cbmc/proofs/skipNumber/skipNumber_harness.c
@@ -32,7 +32,7 @@ void harness()
 {
     char * buf;
     size_t start, max;
-    bool_ ret;
+    bool ret;
     int32_t * outValue;
 
     /* max is the buffer length which must be nonzero for non-API functions. */
@@ -47,7 +47,7 @@ void harness()
 
     ret = skipNumber( buf, &start, max );
 
-    __CPROVER_assert( boolEnum( ret ), "A bool_ value is returned." );
+    __CPROVER_assert( isBool( ret ), "A bool value is returned." );
 
     if( ret == true )
     {
@@ -60,7 +60,7 @@ void harness()
 
     ret = skipDigits( buf, &start, max, outValue );
 
-    __CPROVER_assert( boolEnum( ret ), "A bool_ value is returned." );
+    __CPROVER_assert( isBool( ret ), "A bool value is returned." );
 
     if( ( ret == true ) && ( outValue != NULL ) )
     {

--- a/test/cbmc/proofs/skipSpaceAndComma/skipSpaceAndComma_harness.c
+++ b/test/cbmc/proofs/skipSpaceAndComma/skipSpaceAndComma_harness.c
@@ -32,7 +32,7 @@ void harness()
 {
     char * buf;
     size_t start, max;
-    bool_ ret;
+    bool ret;
 
     /* max is the buffer length which must be nonzero for non-API functions. */
     __CPROVER_assume( max > 0 );
@@ -46,7 +46,7 @@ void harness()
 
     ret = skipSpaceAndComma( buf, &start, max );
 
-    __CPROVER_assert( boolEnum( ret ), "A bool_ value is returned." );
+    __CPROVER_assert( isBool( ret ), "A bool value is returned." );
 
     if( ret == true )
     {

--- a/test/cbmc/proofs/skipString/skipString_harness.c
+++ b/test/cbmc/proofs/skipString/skipString_harness.c
@@ -32,7 +32,7 @@ void harness()
 {
     char * buf;
     size_t start, max;
-    bool_ ret;
+    bool ret;
 
     /* max is the buffer length which must be nonzero for non-API functions. */
     __CPROVER_assume( max > 0 );
@@ -46,7 +46,7 @@ void harness()
 
     ret = skipString( buf, &start, max );
 
-    __CPROVER_assert( boolEnum( ret ), "A bool_ value is returned." );
+    __CPROVER_assert( isBool( ret ), "A bool value is returned." );
 
     if( ret == true )
     {

--- a/test/cbmc/proofs/skipUTF8/skipUTF8_harness.c
+++ b/test/cbmc/proofs/skipUTF8/skipUTF8_harness.c
@@ -32,7 +32,7 @@ void harness()
 {
     char * buf;
     size_t start, max;
-    bool_ ret;
+    bool ret;
 
     /* max is the buffer length which must be nonzero for non-API functions. */
     __CPROVER_assume( max > 0 );
@@ -46,7 +46,7 @@ void harness()
 
     ret = skipUTF8( buf, &start, max );
 
-    __CPROVER_assert( boolEnum( ret ), "A bool_ value is returned." );
+    __CPROVER_assert( isBool( ret ), "A bool value is returned." );
 
     if( ret == true )
     {

--- a/test/cbmc/stubs/skipAnyLiteral.c
+++ b/test/cbmc/stubs/skipAnyLiteral.c
@@ -27,9 +27,9 @@
  * Please see core_json.c for documentation.
  */
 
-bool_ skipAnyLiteral( const char * buf,
-                      size_t * start,
-                      size_t max )
+bool skipAnyLiteral( const char * buf,
+                     size_t * start,
+                     size_t max )
 {
     /* min argument is 4 for the shortest literal, e.g., true or null. */
     return skipGeneric( buf, start, max, 4 );

--- a/test/cbmc/stubs/skipAnyScalar.c
+++ b/test/cbmc/stubs/skipAnyScalar.c
@@ -27,9 +27,9 @@
  * Please see core_json.c for documentation.
  */
 
-bool_ skipAnyScalar( const char * buf,
-                     size_t * start,
-                     size_t max )
+bool skipAnyScalar( const char * buf,
+                    size_t * start,
+                    size_t max )
 {
     /* min argument is 1 for a single character scalar like 0,
      * or 2 for an empty double-quoted string, i.e., "". */

--- a/test/cbmc/stubs/skipDigits.c
+++ b/test/cbmc/stubs/skipDigits.c
@@ -27,13 +27,13 @@
  * Please see core_json.c for documentation.
  */
 
-bool_ skipDigits( const char * buf,
-                  size_t * start,
-                  size_t max,
-                  int32_t * outValue )
+bool skipDigits( const char * buf,
+                 size_t * start,
+                 size_t max,
+                 int32_t * outValue )
 {
     /* min argument is 1 for a single digit, e.g., 0. */
-    bool_ ret = skipGeneric( buf, start, max, 1 );
+    bool ret = skipGeneric( buf, start, max, 1 );
 
     if( ( ret == true ) && ( outValue != NULL ) )
     {

--- a/test/cbmc/stubs/skipEscape.c
+++ b/test/cbmc/stubs/skipEscape.c
@@ -27,9 +27,9 @@
  * Please see core_json.c for documentation.
  */
 
-bool_ skipEscape( const char * buf,
-                  size_t * start,
-                  size_t max )
+bool skipEscape( const char * buf,
+                 size_t * start,
+                 size_t max )
 {
     /* min argument is 2, since the smallest proper
     * escape sequence is 2 characters, e.g., \n. */

--- a/test/cbmc/stubs/skipGeneric.c
+++ b/test/cbmc/stubs/skipGeneric.c
@@ -27,12 +27,12 @@
  *
  * Advance buffer index beyond some minimum value.
  */
-static bool_ skipGeneric( const char * buf,
-                          size_t * start,
-                          size_t max,
-                          size_t min )
+static bool skipGeneric( const char * buf,
+                         size_t * start,
+                         size_t max,
+                         size_t min )
 {
-    bool_ ret = false;
+    bool ret = false;
 
     assert( ( buf != NULL ) && ( start != NULL ) );
     assert( min > 0 );

--- a/test/cbmc/stubs/skipNumber.c
+++ b/test/cbmc/stubs/skipNumber.c
@@ -27,9 +27,9 @@
  * Please see core_json.c for documentation.
  */
 
-bool_ skipNumber( const char * buf,
-                  size_t * start,
-                  size_t max )
+bool skipNumber( const char * buf,
+                 size_t * start,
+                 size_t max )
 {
     /* min argument is 1 for a single digit, e.g., 0. */
     return skipGeneric( buf, start, max, 1 );

--- a/test/cbmc/stubs/skipSpaceAndComma.c
+++ b/test/cbmc/stubs/skipSpaceAndComma.c
@@ -27,9 +27,9 @@
  * Please see core_json.c for documentation.
  */
 
-bool_ skipSpaceAndComma( const char * buf,
-                         size_t * start,
-                         size_t max )
+bool skipSpaceAndComma( const char * buf,
+                        size_t * start,
+                        size_t max )
 {
     /* The original function will match 0 or more spaces, followed by a comma,
      * followed by 0 or more spaces. The spaces are still skipped if there is no comma.

--- a/test/cbmc/stubs/skipString.c
+++ b/test/cbmc/stubs/skipString.c
@@ -27,9 +27,9 @@
  * Please see core_json.c for documentation.
  */
 
-bool_ skipString( const char * buf,
-                  size_t * start,
-                  size_t max )
+bool skipString( const char * buf,
+                 size_t * start,
+                 size_t max )
 {
     /* min argument is 2 for an empty double-quoted string, i.e., "". */
     return skipGeneric( buf, start, max, 2 );

--- a/test/cbmc/stubs/skipUTF8.c
+++ b/test/cbmc/stubs/skipUTF8.c
@@ -27,9 +27,9 @@
  * Please see core_json.c for documentation.
  */
 
-bool_ skipUTF8( const char * buf,
-                size_t * start,
-                size_t max )
+bool skipUTF8( const char * buf,
+               size_t * start,
+               size_t max )
 {
     /* min argument is 1 for a single ASCII character. */
     return skipGeneric( buf, start, max, 1 );


### PR DESCRIPTION
Following the example of coreMQTT, this PR replaces the internal bool_ enum with use of stdbool.h.