### PR TITLE
Add stdint.readme file for toolchains that dont support stdint.h

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,7 @@ jobs:
         run: |
           mkdir -p override-include
           cp source/include/stdbool.readme override-include/stdbool.h
+          cp source/include/stdint.readme override-include/stdint.h
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
           -DBUILD_CLONE_SUBMODULES=ON \

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ A search may descend through nested objects when the `queryKey` contains matchin
 
 A compiler that supports **C90 or later** such as *gcc* is required to build the library.
 
-The library uses a header file introduced in ISO C99, `stdbool.h`. For compilers that do not provide this header file, the [source/include](source/include) directory contains [stdbool.readme](source/include/stdbool.readme), which can be renamed to `stdbool.h`.
+Additionally, the library uses 2 header files introduced in ISO C99, `stdbool.h` and `stdint.h`. For compilers that do not provide this header file, the [source/include](source/include) directory contains [stdbool.readme](source/include/stdbool.readme) and [stdbool.readme](source/include/stdint.readme), which can be renamed to `stdbool.h` and `stdint.h` respectively.
 
 For instance, if the example above is copied to a file named `example.c`, *gcc* can be used like so:
 ```bash

--- a/source/include/stdint.readme
+++ b/source/include/stdint.readme
@@ -26,7 +26,7 @@ typedef long long            int64_t;
 typedef unsigned long long   uint64_t;
 
 #define INT8_MAX      ( ( signed char ) 127 )
-#define UINT8_MAX     ( ( unsigned char ) ) 255
+#define UINT8_MAX     ( ( unsigned char ) 255 )
 #define INT16_MAX     ( ( short ) 32767 )
 #define UINT16_MAX    ( ( unsigned short ) 65535 )
 #define INT32_MAX     2147483647L

--- a/source/include/stdint.readme
+++ b/source/include/stdint.readme
@@ -1,0 +1,37 @@
+#ifndef _STDINT_H
+#define _STDINT_H
+
+/*******************************************************************************
+ * THIS IS NOT A FULL stdint.h IMPLEMENTATION - It only contains the definitions
+ * necessary to build the coreMQTT code.  It is provided to allow coreMQTT to be
+ * built using compilers that do not provide their own stdint.h definition.
+ *
+ * To use this file:
+ *
+ *    1) Copy this file into a directory that is in your compiler's include path.
+ *       The directory must be part of the include path for system header file,
+ *       for example passed using gcc's "-I" or "-isystem" options.
+ *
+ *    2) Rename the copied file stdint.h.
+ *
+ */
+
+typedef signed char          int8_t;
+typedef unsigned char        uint8_t;
+typedef short                int16_t;
+typedef unsigned short       uint16_t;
+typedef long                 int32_t;
+typedef unsigned long        uint32_t;
+typedef long long            int64_t;
+typedef unsigned long long   uint64_t;
+
+#define INT8_MAX      ( ( signed char ) 127 )
+#define UINT8_MAX     ( ( unsigned char ) ) 255
+#define INT16_MAX     ( ( short ) 32767 )
+#define UINT16_MAX    ( ( unsigned short ) 65535 )
+#define INT32_MAX     2147483647L
+#define UINT32_MAX    4294967295UL
+#define INT64_MAX     9223372036854775807LL
+#define UINT64_MAX    18446744073709551615ULL
+
+#endif /* _STDINT_H */

--- a/source/include/stdint.readme
+++ b/source/include/stdint.readme
@@ -3,8 +3,8 @@
 
 /*******************************************************************************
  * THIS IS NOT A FULL stdint.h IMPLEMENTATION - It only contains the definitions
- * necessary to build the coreMQTT code.  It is provided to allow coreMQTT to be
- * built using compilers that do not provide their own stdint.h definition.
+ * necessary to build the library code.  It is provided to allow the library to
+ * be built using compilers that do not provide their own stdint.h definition.
  *
  * To use this file:
  *


### PR DESCRIPTION
Add a `stdint.readme` file that can be used for toolchains that do not support the `stdint.h` standard C header file