### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A search may descend through nested objects when the `queryKey` contains matchin
 
 A compiler that supports **C90 or later** such as *gcc* is required to build the library.
 
-Additionally, the library uses 2 header files introduced in ISO C99, `stdbool.h` and `stdint.h`. For compilers that do not provide this header file, the [source/include](source/include) directory contains [stdbool.readme](source/include/stdbool.readme) and [stdbool.readme](source/include/stdint.readme), which can be renamed to `stdbool.h` and `stdint.h` respectively.
+Additionally, the library uses 2 header files introduced in ISO C99, `stdbool.h` and `stdint.h`. For compilers that do not provide this header file, the [source/include](source/include) directory contains [stdbool.readme](source/include/stdbool.readme) and [stdint.readme](source/include/stdint.readme), which can be renamed to `stdbool.h` and `stdint.h` respectively.
 
 For instance, if the example above is copied to a file named `example.c`, *gcc* can be used like so:
 ```bash


### PR DESCRIPTION
Fixed name of link to `stdint.readme` that was named `stdbool.readme`.