### PR TITLE
Use python 3.7.10 for memory estimator check.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
             submodules: 'recursive'
+      - name: Install Python3
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7.10'
       - name: Measure sizes
         uses: FreeRTOS/CI-CD-Github-Actions/memory_statistics@main
         with:


### PR DESCRIPTION
Use python 3.7.10 for memory estimator check.