### PR TITLE
Fix sed expressions to use bool instead of bool_.

### DIFF
--- a/test/cbmc/proofs/JSON_Iterate/Makefile
+++ b/test/cbmc/proofs/JSON_Iterate/Makefile
@@ -24,4 +24,4 @@ include ../Makefile-json.common
 
 # Substitution command to pass to sed for patching core_json.c. The
 # characters " and # must be escaped with backslash.
-CORE_JSON_SED_EXPR = 1s/^/\#include \"core_json_annex.h\" /; s/^static //; s/(bool_|void|JSONStatus_t) skip(AnyScalar|Collection|Digits|Space|SpaceAndComma|String)\b/&_/
+CORE_JSON_SED_EXPR = 1s/^/\#include \"core_json_annex.h\" /; s/^static //; s/(bool|void|JSONStatus_t) skip(AnyScalar|Collection|Digits|Space|SpaceAndComma|String)\b/&_/

--- a/test/cbmc/proofs/JSON_Search/Makefile
+++ b/test/cbmc/proofs/JSON_Search/Makefile
@@ -32,4 +32,4 @@ include ../Makefile-json.common
 
 # Substitution command to pass to sed for patching core_json.c. The
 # characters " and # must be escaped with backslash.
-CORE_JSON_SED_EXPR = 1s/^/\#include \"core_json_annex.h\" /; s/^static //; s/(bool_|void|JSONStatus_t) skip(AnyScalar|Collection|Digits|Space|SpaceAndComma|String)\b/&_/
+CORE_JSON_SED_EXPR = 1s/^/\#include \"core_json_annex.h\" /; s/^static //; s/(bool|void|JSONStatus_t) skip(AnyScalar|Collection|Digits|Space|SpaceAndComma|String)\b/&_/

--- a/test/cbmc/proofs/JSON_Validate/Makefile
+++ b/test/cbmc/proofs/JSON_Validate/Makefile
@@ -21,4 +21,4 @@ include ../Makefile-json.common
 
 # Substitution command to pass to sed for patching core_json.c. The
 # characters " and # must be escaped with backslash.
-CORE_JSON_SED_EXPR = 1s/^/\#include \"core_json_annex.h\" /; s/^static //; s/(bool_|JSONStatus_t|void) skip(AnyLiteral|Collection|Number|Space|String)\b/&_/
+CORE_JSON_SED_EXPR = 1s/^/\#include \"core_json_annex.h\" /; s/^static //; s/(bool|JSONStatus_t|void) skip(AnyLiteral|Collection|Number|Space|String)\b/&_/

--- a/test/cbmc/proofs/skipCollection/Makefile
+++ b/test/cbmc/proofs/skipCollection/Makefile
@@ -26,4 +26,4 @@ include ../Makefile-json.common
 
 # Substitution command to pass to sed for patching core_json.c. The
 # characters " and # must be escaped with backslash.
-CORE_JSON_SED_EXPR = 1s/^/\#include \"core_json_annex.h\" /; s/^static //; s/(bool_|void) skip(AnyLiteral|Number|Space|SpaceAndComma|String)\b/&_/
+CORE_JSON_SED_EXPR = 1s/^/\#include \"core_json_annex.h\" /; s/^static //; s/(bool|void) skip(AnyLiteral|Number|Space|SpaceAndComma|String)\b/&_/

--- a/test/cbmc/proofs/skipString/Makefile
+++ b/test/cbmc/proofs/skipString/Makefile
@@ -18,4 +18,4 @@ include ../Makefile-json.common
 
 # Substitution command to pass to sed for patching core_json.c. The
 # characters " and # must be escaped with backslash.
-CORE_JSON_SED_EXPR = 1s/^/\#include \"core_json_annex.h\" /; s/^static //; s/bool_ skip(Escape|UTF8)\b/&_/
+CORE_JSON_SED_EXPR = 1s/^/\#include \"core_json_annex.h\" /; s/^static //; s/bool skip(Escape|UTF8)\b/&_/

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -17,7 +17,7 @@ execute_process( COMMAND sed "s/^static //"
         )
 
 # Generate a header file for internal functions
-execute_process( COMMAND sed -n "1s/.*/typedef int bool_;/p; /^static.*(/,/^{\$/{s/^static //; s/)\$/&;/; /{/d; p;}"
+execute_process( COMMAND sed -n "/^static.*(/,/^{\$/{s/^static //; s/)\$/&;/; /{/d; p;}"
                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
                  INPUT_FILE ${JSON_SOURCES}
                  OUTPUT_FILE ${TEMP_BASE}_annex.h


### PR DESCRIPTION
The earlier conversion from the private bool_ to standard bool was not reflected in the sed expressions present in the CBMC makefiles.  This PR fixes that omission.