### PR TITLE
Wrap query key separator macro with ifndef

### DIFF
--- a/source/core_json.c
+++ b/source/core_json.c
@@ -1435,7 +1435,9 @@ static bool arraySearch( const char * buf,
  * @return true if a valid string was present;
  * false otherwise.
  */
-#define JSON_QUERY_KEY_SEPARATOR    '.'
+#ifndef JSON_QUERY_KEY_SEPARATOR
+    #define JSON_QUERY_KEY_SEPARATOR    '.'
+#endif
 #define isSeparator_( x )    ( ( x ) == JSON_QUERY_KEY_SEPARATOR )
 static bool skipQueryPart( const char * buf,
                            size_t * start,


### PR DESCRIPTION
Requested in issue https://github.com/FreeRTOS/coreJSON/issues/92

This change allows the separator character to be overridden by defining the macro on the command line.

     $ gcc -ansi -Wall -Iinclude "-DJSON_QUERY_KEY_SEPARATOR='|'" -c core_json.c