### PR TITLE
Eliminate warnings when base char type is unsigned

### DIFF
--- a/docs/doxygen/include/size_table.html
+++ b/docs/doxygen/include/size_table.html
@@ -9,12 +9,12 @@
     </tr>
     <tr>
         <td>core_json.c</td>
-        <td><center>2.7K</center></td>
-        <td><center>2.2K</center></td>
+        <td><center>2.9K</center></td>
+        <td><center>2.3K</center></td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>2.7K</center></b></td>
-        <td><b><center>2.2K</center></b></td>
+        <td><b><center>2.9K</center></b></td>
+        <td><b><center>2.3K</center></b></td>
     </tr>
 </table>

--- a/source/core_json.c
+++ b/source/core_json.c
@@ -26,6 +26,7 @@
  */
 
 #include <assert.h>
+#include <limits.h>
 #include <stddef.h>
 #include <stdint.h>
 #include "core_json.h"
@@ -39,8 +40,13 @@ typedef union
     uint8_t u;
 } char_;
 
-#define isdigit_( x )    ( ( ( x ) >= '0' ) && ( ( x ) <= '9' ) )
-#define iscntrl_( x )    ( ( ( x ) >= '\0' ) && ( ( x ) < ' ' ) )
+#if ( CHAR_MIN == 0 )
+    #define isascii_( x )    ( ( x ) <= '\x7F' )
+#else
+    #define isascii_( x )    ( ( x ) >= '\0' )
+#endif
+#define iscntrl_( x )        ( isascii_( x ) && ( ( x ) < ' ' ) )
+#define isdigit_( x )        ( ( ( x ) >= '0' ) && ( ( x ) <= '9' ) )
 /* NB. This is whitespace as defined by the JSON standard (ECMA-404). */
 #define isspace_( x )                          \
     ( ( ( x ) == ' ' ) || ( ( x ) == '\t' ) || \
@@ -190,7 +196,7 @@ static bool skipUTF8MultiByte( const char * buf,
 
     i = *start;
     assert( i < max );
-    assert( buf[ i ] < '\0' );
+    assert( !isascii_( buf[ i ] ) );
 
     c.c = buf[ i ];
 
@@ -251,8 +257,7 @@ static bool skipUTF8( const char * buf,
 
     if( *start < max )
     {
-        /* an ASCII byte */
-        if( buf[ *start ] >= '\0' )
+        if( isascii_( buf[ *start ] ) )
         {
             *start += 1U;
             ret = true;


### PR DESCRIPTION
The C standard leaves it to the implementation as to the signedness of type char.  When char was signed all was well, but when char was unsigned, some comparisons gave compiler warnings: "comparison is always true due to limited range of data type [-Wtype-limits]".  This PR resolves those warnings.