### PR TITLE
Protect against an integer overflow

### DIFF
--- a/source/core_json.c
+++ b/source/core_json.c
@@ -333,8 +333,13 @@ static bool skipOneHexEscape( const char * buf,
     assert( ( buf != NULL ) && ( start != NULL ) && ( max > 0U ) );
     assert( outValue != NULL );
 
-    i = *start;
 #define HEX_ESCAPE_LENGTH    ( 6U )   /* e.g., \u1234 */
+    if (*start > SIZE_MAX - HEX_ESCAPE_LENGTH)
+    {
+        return false;
+    }
+
+    i = *start;
     end = i + HEX_ESCAPE_LENGTH;
 
     if( ( end < max ) && ( buf[ i ] == '\\' ) && ( buf[ i + 1U ] == 'u' ) )


### PR DESCRIPTION
This pull request has skipOneHexEscape return false if *start is too large to protect against an integer overflow in the calculation of end.