### PR TITLE
Fix overflow in skipOneHexEscape()

### DIFF
--- a/source/core_json.c
+++ b/source/core_json.c
@@ -335,7 +335,7 @@ static bool skipOneHexEscape( const char * buf,
 
     i = *start;
 #define HEX_ESCAPE_LENGTH    ( 6U )   /* e.g., \u1234 */
-    end = i + HEX_ESCAPE_LENGTH;
+    end = ( i <= ( SIZE_MAX - HEX_ESCAPE_LENGTH ) ) ? ( i + HEX_ESCAPE_LENGTH ) : SIZE_MAX;
 
     if( ( end < max ) && ( buf[ i ] == '\\' ) && ( buf[ i + 1U ] == 'u' ) )
     {

--- a/source/include/stdint.readme
+++ b/source/include/stdint.readme
@@ -25,13 +25,17 @@ typedef unsigned long        uint32_t;
 typedef long long            int64_t;
 typedef unsigned long long   uint64_t;
 
-#define INT8_MAX      ( ( signed char ) 127 )
-#define UINT8_MAX     ( ( unsigned char ) 255 )
-#define INT16_MAX     ( ( short ) 32767 )
-#define UINT16_MAX    ( ( unsigned short ) 65535 )
-#define INT32_MAX     2147483647L
-#define UINT32_MAX    4294967295UL
-#define INT64_MAX     9223372036854775807LL
-#define UINT64_MAX    18446744073709551615ULL
+#define INT8_MAX        ( ( signed char ) 127 )
+#define UINT8_MAX       ( ( unsigned char ) 255 )
+#define INT16_MAX       ( ( short ) 32767 )
+#define UINT16_MAX      ( ( unsigned short ) 65535 )
+#define INT32_MAX       2147483647L
+#define UINT32_MAX      4294967295UL
+#define INT64_MAX       9223372036854775807LL
+#define UINT64_MAX      18446744073709551615ULL
+
+#ifndef SIZE_MAX
+    #define SIZE_MAX    ( ( size_t ) -1 )
+#endif
 
 #endif /* _STDINT_H */

--- a/test/unit-test/core_json_utest.c
+++ b/test/unit-test/core_json_utest.c
@@ -1871,3 +1871,16 @@ void test_JSON_unreached( void )
                            iterate( buf, max, &start, &next, &key, &keyLength, &value, &valueLength ) );
     }
 }
+
+/**
+ * @brief Test overflows.
+ */
+void test_JSON_overflows( void )
+{
+    char buf[] = UNICODE_ESCAPE_SEQUENCES_BMP;
+    size_t start;
+    uint16_t u;
+
+    start = SIZE_MAX;
+    TEST_ASSERT_EQUAL( false, skipOneHexEscape( buf, &start, SIZE_MAX, &u ) );
+}


### PR DESCRIPTION
This fixes the same overflow as https://github.com/FreeRTOS/coreJSON/pull/97 , and adds a unit test and a definition of SIZE_MAX for archaic compilers.

I hope this PR exercises the LGTM PR integration just added to this repo.