### PR TITLE
Remove non-c/cpp languages from LGTM config

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -7,19 +7,3 @@ extraction:
       build_command:
         - export 'CFLAGS=-Iinclude -ansi -Wall -Wextra -Wpedantic -Werror'
         - make -C source core_json.o
-
-  csharp:
-    after_prepare:
-      - false
-  go:
-    after_prepare:
-      - false
-  java:
-    after_prepare:
-      - false
-  javascript:
-    after_prepare:
-      - false
-  python:
-    after_prepare:
-      - false


### PR DESCRIPTION
Now that the CBMC kit copies python files into the repo, the check fails.