### PR TITLE
Avoid spurious arithmetic overflow in CBMC proofs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ build/
 *.gcda
 *.gcno
 *.gcov
+
+# Ignore macOS artifacts
+.DS_Store

--- a/test/cbmc/stubs/skipGeneric.c
+++ b/test/cbmc/stubs/skipGeneric.c
@@ -41,7 +41,8 @@ static bool skipGeneric( const char * buf,
 
     if( *start < max )
     {
-        assert( __CPROVER_r_ok( ( buf + *start ), ( max - *start ) ) );
+        size_t readable_length = max - *start;
+        assert( __CPROVER_r_ok( ( buf + *start ), readable_length ) );
 
         if( nondet_bool() && ( min <= max ) )
         {


### PR DESCRIPTION
Avoid spurious arithmetic overflow in CBMC proofs when using `__CPROVER_r_ok`. I also suggest an update to `.gitignore` to include `.DS_Store` files generated on macOS.