### PR TITLE
Fix MISRA C 2012 rule 20.12 deviations

### DIFF
--- a/source/core_json.c
+++ b/source/core_json.c
@@ -1036,7 +1036,15 @@ static void skipScalars( const char * buf,
                          size_t max,
                          char mode )
 {
-    assert( isOpenBracket_( mode ) );
+    bool modeIsOpenBracket = ( bool ) isOpenBracket_( mode );
+
+    /* assert function may be implemented in macro using a # or ## operator.
+     * Using a local variable here to prevent macro replacement is subjected
+     * to macro itself. */
+    assert( modeIsOpenBracket != false );
+
+    /* Adding this line to avoid unused variable warning in release mode. */
+    ( void ) modeIsOpenBracket;
 
     skipSpace( buf, start, max );
 


### PR DESCRIPTION
Fix MISRA C 2012 20.12 deviations

Description
-----------
MISRA C 2012 rule 20.12 
> A macro parameter that is used as an operand of a # or ## operator is not expanded prior to being
used.

assert may be implemented using a # or ## operator. In this case, macro replacement is subjected to macro itself. The result may not be meet developer expectations.

**In this PR:**
* Use a local variable here to prevent macro replacement is subjected to macro itself.

Test Steps
-----------
Issue #152 indicates this error.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
#152
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
