### PR TITLE
Correctly detect missing key in a key-value pair

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         uses: FreeRTOS/CI-CD-Github-Actions/complexity@main
         with:
           path: ./
+          horrid_threshold: 12
 
   doxygen:
     runs-on: ubuntu-latest

--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -9,12 +9,12 @@
     </tr>
     <tr>
         <td>core_json.c</td>
-        <td><center>2.9K</center></td>
-        <td><center>2.4K</center></td>
+        <td><center>3.1K</center></td>
+        <td><center>2.5K</center></td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>2.9K</center></b></td>
-        <td><b><center>2.4K</center></b></td>
+        <td><b><center>3.1K</center></b></td>
+        <td><b><center>2.5K</center></b></td>
     </tr>
 </table>

--- a/loop_invariants.patch
+++ b/loop_invariants.patch
@@ -123,7 +123,7 @@ index 901b2e1..8bdd89c 100644
      {
          if( skipAnyScalar( buf, &i, max ) != true )
          {
-@@ -986,6 +1037,13 @@ static void skipObjectScalars( const char * buf,
+@@ -986,6 +1037,13 @@ static bool skipObjectScalars( const char * buf,
      i = *start;
  
      while( i < max )

--- a/source/core_json.c
+++ b/source/core_json.c
@@ -1121,10 +1121,12 @@ static JSONStatus_t skipCollection( const char * buf,
                 }
 
                 stack[ depth ] = c;
+
                 if( skipScalars( buf, &i, max, stack[ depth ] ) != true )
                 {
                     ret = JSONIllegalDocument;
                 }
+
                 break;
 
             case '}':

--- a/source/core_json.c
+++ b/source/core_json.c
@@ -971,14 +971,18 @@ static void skipArrayScalars( const char * buf,
  * @param[in,out] start  The index at which to begin.
  * @param[in] max  The size of the buffer.
  *
+ * @return true if a valid scalar key-value pairs were present;
+ * false otherwise.
+ *
  * @note Stops advance if a value is an object or array.
  */
-static void skipObjectScalars( const char * buf,
+static bool skipObjectScalars( const char * buf,
                                size_t * start,
                                size_t max )
 {
     size_t i = 0U;
     bool comma = false;
+    bool ret = true;
 
     coreJSON_ASSERT( ( buf != NULL ) && ( start != NULL ) && ( max > 0U ) );
 
@@ -988,6 +992,7 @@ static void skipObjectScalars( const char * buf,
     {
         if( skipString( buf, &i, max ) != true )
         {
+            ret = false;
             break;
         }
 
@@ -995,6 +1000,7 @@ static void skipObjectScalars( const char * buf,
 
         if( ( i < max ) && ( buf[ i ] != ':' ) )
         {
+            ret = false;
             break;
         }
 
@@ -1009,6 +1015,7 @@ static void skipObjectScalars( const char * buf,
 
         if( skipAnyScalar( buf, &i, max ) != true )
         {
+            ret = false;
             break;
         }
 
@@ -1020,6 +1027,8 @@ static void skipObjectScalars( const char * buf,
             break;
         }
     }
+
+    return ret;
 }
 
 /**
@@ -1029,13 +1038,17 @@ static void skipObjectScalars( const char * buf,
  * @param[in,out] start  The index at which to begin.
  * @param[in] max  The size of the buffer.
  * @param[in] mode  The first character of an array '[' or object '{'.
+ *
+ * @return true if a valid scalers were present;
+ * false otherwise.
  */
-static void skipScalars( const char * buf,
+static bool skipScalars( const char * buf,
                          size_t * start,
                          size_t max,
                          char mode )
 {
     bool modeIsOpenBracket = ( bool ) isOpenBracket_( mode );
+    bool ret = true;
 
     /* assert function may be implemented in macro using a # or ## operator.
      * Using a local variable here to prevent macro replacement is subjected
@@ -1053,8 +1066,10 @@ static void skipScalars( const char * buf,
     }
     else
     {
-        skipObjectScalars( buf, start, max );
+        ret = skipObjectScalars( buf, start, max );
     }
+
+    return ret;
 }
 
 /**
@@ -1106,7 +1121,10 @@ static JSONStatus_t skipCollection( const char * buf,
                 }
 
                 stack[ depth ] = c;
-                skipScalars( buf, &i, max, stack[ depth ] );
+                if( skipScalars( buf, &i, max, stack[ depth ] ) != true )
+                {
+                    ret = JSONIllegalDocument;
+                }
                 break;
 
             case '}':
@@ -1120,7 +1138,10 @@ static JSONStatus_t skipCollection( const char * buf,
                     if( ( skipSpaceAndComma( buf, &i, max ) == true ) &&
                         isOpenBracket_( stack[ depth ] ) )
                     {
-                        skipScalars( buf, &i, max, stack[ depth ] );
+                        if( skipScalars( buf, &i, max, stack[ depth ] ) != true )
+                        {
+                            ret = JSONIllegalDocument;
+                        }
                     }
 
                     break;

--- a/test/cbmc/include/core_json_contracts.h
+++ b/test/cbmc/include/core_json_contracts.h
@@ -261,7 +261,7 @@ assigns( *start )
 ensures( skipCollectionPostconditions( result, buf, start, old( *start ), max ) )
 ;
 
-void skipScalars( const char * buf,
+bool skipScalars( const char * buf,
                   size_t * start,
                   size_t max,
                   char mode )

--- a/test/cbmc/include/core_json_contracts.h
+++ b/test/cbmc/include/core_json_contracts.h
@@ -270,7 +270,7 @@ assigns( *start )
 ensures( isValidStart( *start, old( *start ), max ) )
 ;
 
-void skipObjectScalars( const char * buf,
+bool skipObjectScalars( const char * buf,
                         size_t * start,
                         size_t max )
 requires( isValidBufferWithStartIndex( buf, max, start ) )

--- a/test/unit-test/core_json_utest.c
+++ b/test/unit-test/core_json_utest.c
@@ -168,6 +168,15 @@
 #define MISSING_VALUE_AFTER_KEY                            "{\"foo\":{\"bar\":}}"
 #define MISSING_VALUE_AFTER_KEY_LENGTH                     ( sizeof( MISSING_VALUE_AFTER_KEY ) - 1 )
 
+#define MISSING_KEY                                        "{\"foo\":\"bar\", {\"abc\":\"xyz\"}}"
+#define MISSING_KEY_LENGTH                                 ( sizeof( MISSING_KEY ) - 1 )
+
+#define MISSING_VALUE                                      "{\"foo\":{\"abc\":\"xyz\"}, \"bar\":}"
+#define MISSING_VALUE_LENGTH                               ( sizeof( MISSING_VALUE ) - 1 )
+
+#define MISSING_SEPERATOR                                  "{\"foo\" \"bar\"}"
+#define MISSING_SEPERATOR_LENGTH                           ( sizeof( MISSING_SEPERATOR ) - 1 )
+
 #define MISMATCHED_BRACKETS                                "{\"foo\":{\"bar\":\"xyz\"]}"
 #define MISMATCHED_BRACKETS_LENGTH                         ( sizeof( MISMATCHED_BRACKETS ) - 1 )
 
@@ -617,6 +626,18 @@ void test_JSON_Validate_Illegal_Documents( void )
 
     jsonStatus = JSON_Validate( MISSING_VALUE_AFTER_KEY,
                                 MISSING_VALUE_AFTER_KEY_LENGTH );
+    TEST_ASSERT_EQUAL( JSONIllegalDocument, jsonStatus );
+
+    jsonStatus = JSON_Validate( MISSING_KEY,
+                                MISSING_KEY_LENGTH );
+    TEST_ASSERT_EQUAL( JSONIllegalDocument, jsonStatus );
+
+    jsonStatus = JSON_Validate( MISSING_VALUE,
+                                MISSING_VALUE_LENGTH );
+    TEST_ASSERT_EQUAL( JSONIllegalDocument, jsonStatus );
+
+    jsonStatus = JSON_Validate( MISSING_SEPERATOR,
+                                MISSING_SEPERATOR_LENGTH );
     TEST_ASSERT_EQUAL( JSONIllegalDocument, jsonStatus );
 
     jsonStatus = JSON_Validate( MISMATCHED_BRACKETS,


### PR DESCRIPTION
Description
-----------
The following invalid JSON document would be classified as valid JSON without this change:
```
{
    "key1":"val1",
    {
        "key2":"val2"
    }
}
```

The issue was reported here - https://github.com/FreeRTOS/coreJSON/issues/165.


Test Steps
-----------
Run updated unit tests.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/FreeRTOS/coreJSON/issues/165

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
